### PR TITLE
Set the base API path on the management URL inside the New method for the connector

### DIFF
--- a/cmd/baton-sentinel-one/main.go
+++ b/cmd/baton-sentinel-one/main.go
@@ -8,9 +8,10 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/types"
-	"github.com/conductorone/baton-sentinel-one/pkg/connector"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+
+	"github.com/conductorone/baton-sentinel-one/pkg/connector"
 )
 
 var version = "dev"
@@ -38,8 +39,7 @@ func main() {
 func getConnector(ctx context.Context, cfg *config) (types.ConnectorServer, error) {
 	l := ctxzap.Extract(ctx)
 
-	baseUrl := fmt.Sprintf("%s/web/api/v2.1/", cfg.ManagementUrl)
-	sentineloneConnector, err := connector.New(ctx, baseUrl, cfg.Token)
+	sentineloneConnector, err := connector.New(ctx, cfg.ManagementUrl, cfg.Token)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -3,13 +3,15 @@ package connector
 import (
 	"context"
 	"fmt"
+	"path"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
-	"github.com/conductorone/baton-sentinel-one/pkg/sentinelone"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+
+	"github.com/conductorone/baton-sentinel-one/pkg/sentinelone"
 )
 
 type SentinelOne struct {
@@ -114,7 +116,7 @@ func New(ctx context.Context, baseUrl, token string) (*SentinelOne, error) {
 		return nil, err
 	}
 
-	client := sentinelone.NewClient(httpClient, baseUrl, token)
+	client := sentinelone.NewClient(httpClient, path.Join(baseUrl, "web/api/v2.1/"), token)
 
 	return &SentinelOne{
 		client: client,


### PR DESCRIPTION
Because this was happening in the higher CLI layer, it results in errors when trying to use the connector as a library. This moves the path setting lower down so that it always happens when the connector is created.