### PR TITLE
Use the URL builder instead of trying to path join together

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -3,7 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
-	"path"
+	"net/url"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -116,7 +116,13 @@ func New(ctx context.Context, baseUrl, token string) (*SentinelOne, error) {
 		return nil, err
 	}
 
-	client := sentinelone.NewClient(httpClient, path.Join(baseUrl, "web/api/v2.1/"), token)
+	clientUrl, err := url.Parse(baseUrl)
+	if err != nil {
+		return nil, err
+	}
+	clientUrl.Path = "/web/api/v2.1/"
+
+	client := sentinelone.NewClient(httpClient, clientUrl.String(), token)
 
 	return &SentinelOne{
 		client: client,


### PR DESCRIPTION
`path.Join()` breaks on full urls. Use the actual URL library to build the base url.