### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-sentinel-one/main.go
+++ b/cmd/baton-sentinel-one/main.go
@@ -44,7 +44,12 @@ func main() {
 func getConnector(ctx context.Context, c *cfg.Sentinelone) (types.ConnectorServer, error) {
 	l := ctxzap.Extract(ctx)
 
-	sentineloneConnector, err := connector.New(ctx, c.ManagementConsoleUrl, c.ApiToken)
+	baseURL := c.ManagementConsoleUrl
+	if c.BaseUrl != "" {
+		baseURL = c.BaseUrl
+	}
+
+	sentineloneConnector, err := connector.New(ctx, baseURL, c.ApiToken)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type Sentinelone struct {
 	ApiToken string `mapstructure:"api-token"`
 	ManagementConsoleUrl string `mapstructure:"management-console-url"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Sentinelone) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the SentinelOne API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,11 @@ var (
 		field.WithPlaceholder("Your SentinelOne base URL"),
 		field.WithRequired(true),
 	)
+
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the SentinelOne API URL (for testing)"),
+	)
 )
 
 //go:generate go run ./gen
@@ -28,6 +33,7 @@ var Config = field.NewConfiguration(
 	[]field.SchemaField{
 		APIToken,
 		ManagementConsoleURL,
+		BaseURLField,
 	},
 	field.WithConnectorDisplayName("SentinelOne"),
 	field.WithHelpUrl("/docs/baton/sentinelone"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the SentinelOne API URL (for testing)"),
+		field.WithHidden(true),
 	)
 )
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -14,6 +14,8 @@ import (
 	"github.com/conductorone/baton-sentinel-one/pkg/sentinelone"
 )
 
+const limitKey = "limit"
+
 type SentinelOne struct {
 	client *sentinelone.Client
 }
@@ -73,34 +75,34 @@ func (s *SentinelOne) Metadata(ctx context.Context) (*v2.ConnectorMetadata, erro
 // It's not defined which role is needed to fetch all resources so we need to check that user has access to all of them.
 func (s *SentinelOne) Validate(ctx context.Context) (annotations.Annotations, error) {
 	_, _, err := s.client.GetAccounts(ctx, sentinelone.ParamsMap{
-		"limit": "1",
+		limitKey: "1",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get accounts: %w", err)
 	}
 
 	_, _, err = s.client.GetSites(ctx, sentinelone.ParamsMap{
-		"limit": "1",
+		limitKey: "1",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sites: %w", err)
 	}
 	_, _, err = s.client.GetUsers(ctx, sentinelone.ParamsMap{
-		"limit": "1",
+		limitKey: "1",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get users: %w", err)
 	}
 
 	_, _, err = s.client.GetServiceUsers(ctx, sentinelone.ParamsMap{
-		"limit": "1",
+		limitKey: "1",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service users: %w", err)
 	}
 
 	_, _, err = s.client.GetPredefinedRoles(ctx, sentinelone.ParamsMap{
-		"limit": "1",
+		limitKey: "1",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get roles: %w", err)


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-sentinel-one/main.go,pkg/config/conf.gen.go,pkg/config/config.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-sentinel-one --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.