### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a SentinelOne connector
 og:title: Set up a SentinelOne connector - C1 docs
-og:description: Integrate your SentinelOne instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for SentinelOne. Integrate your SentinelOne instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for SentinelOne. Integrate your SentinelOne instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for SentinelOne. Integrate your SentinelOne instance with C1 for unified visibility and governance over user access."
 sidebarTitle: SentinelOne
 ---
 
@@ -36,7 +36,7 @@ The API token is created. Carefully copy and save the token.
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the SentinelOne connector
 
@@ -95,7 +95,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your SentinelOne connector is now pulling access data into C1.
+**Done.** Your SentinelOne connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 
@@ -211,7 +211,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your SentinelOne connector is now pulling access data into C1.
+**Done.** Your SentinelOne connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines